### PR TITLE
Replace deprecated serr and sendl identifiers with msg_error()

### DIFF
--- a/src/CGALPlugin/DecimateMesh.inl
+++ b/src/CGALPlugin/DecimateMesh.inl
@@ -266,7 +266,7 @@ void DecimateMesh<DataTypes>::surface_to_geometry(Surface &s)
                 }
                 else
                 {
-                    serr << "We've got facets with more than 3 vertices even though the facet reported to be trianglular..." << sendl;
+                    msg_error() << "We've got facets with more than 3 vertices even though the facet reported to be trianglular...";
                 }
 
             }
@@ -276,7 +276,7 @@ void DecimateMesh<DataTypes>::surface_to_geometry(Surface &s)
         }
         else
         {
-            serr << "Skipping non-trianglular facet" << sendl;
+            msg_error() << "Skipping non-trianglular facet";
         }
 
     }

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
@@ -341,7 +341,7 @@ void MeshGenerationFromPolyhedron<DataTypes>::doUpdate()
             newPoints.push_back(p);
         }
     }
-    if (notconnected > 0) serr << notconnected << " points are not connected to the mesh."<<sendl;
+    if (notconnected > 0) msg_error() << notconnected << " points are not connected to the mesh.";
 
     tetrahedra.clear();
     for( Cell_iterator cit = c3t3.cells_begin() ; cit != c3t3.cells_end() ; ++cit )

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
@@ -341,7 +341,10 @@ void MeshGenerationFromPolyhedron<DataTypes>::doUpdate()
             newPoints.push_back(p);
         }
     }
-    if (notconnected > 0) msg_error() << notconnected << " points are not connected to the mesh.";
+    if (notconnected > 0)
+    {
+        msg_error() << notconnected << " points are not connected to the mesh.";
+    }
 
     tetrahedra.clear();
     for( Cell_iterator cit = c3t3.cells_begin() ; cit != c3t3.cells_end() ; ++cit )

--- a/src/CGALPlugin/Refine2DMesh.inl
+++ b/src/CGALPlugin/Refine2DMesh.inl
@@ -339,7 +339,7 @@ namespace cgal
                             }
                             if (best_fit < 0)
                             {
-                                serr << "Invalid constrained edge." << sendl;
+                                msg_error() << "Invalid constrained edge.";
                                 break;
                             }
                         }


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/sofa-framework/CGALPlugin/issues/2) relating to the deprecation of the serr and sendl identifiers. These were deprecated in [2292](https://github.com/sofa-framework/sofa/pull/2292).

Fix #2