### PR TITLE
[ci] Remove build with SOFA 22.06 and activate test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,35 @@ jobs:
         with:
           name: CGALPlugin_${{ steps.sofa.outputs.run_branch }}_for-SOFA-${{ steps.sofa.outputs.sofa_version }}_${{ runner.os }}
           path: ${{ env.WORKSPACE_ARTIFACT_PATH }}
+          
+      - name: Set env vars for tests
+        shell: bash
+        run: |
+          # Set env vars for tests
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "$WORKSPACE_ARTIFACT_PATH/lib" >> $GITHUB_PATH
+            echo "$WORKSPACE_ARTIFACT_PATH/bin" >> $GITHUB_PATH
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/bin" | tee -a $GITHUB_ENV
+          else
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/lib" | tee -a $GITHUB_ENV
+          fi
 
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "DYLD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$DYLD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+          fi
+
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "LD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+          fi
+
+      - name: Run CGALPlugin_test
+        if: always()
+        shell: bash
+        run: |
+          chmod +x $WORKSPACE_BUILD_PATH/bin/CGALPlugin_test${{ steps.sofa.outputs.exe }}
+          cd $WORKSPACE_BUILD_PATH
+          ./bin/CGALPlugin_test${{ steps.sofa.outputs.exe }}
+      
   deploy:
     name: Deploy artifacts
     if: always() && startsWith(github.ref, 'refs/heads/') # we are on a branch (not a PR)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}
+          sofa_scope: 'standard'
       
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/CGALPlugin_test/CMakeLists.txt
+++ b/CGALPlugin_test/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 add_definitions("-DSOFACGAL_TEST_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../scenes/data/\"")
 add_executable(${PROJECT_NAME} ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} CGALPlugin Sofa.Testing SceneCreator )
+target_link_libraries(${PROJECT_NAME} CGALPlugin Sofa.Testing)
 
 if(image_FOUND)
     target_link_libraries(${PROJECT_NAME} Sofa.Component.StateContainer image)

--- a/CGALPlugin_test/CMakeLists.txt
+++ b/CGALPlugin_test/CMakeLists.txt
@@ -11,20 +11,20 @@ set(SOURCE_FILES
 sofa_find_package(Sofa.Testing REQUIRED)
 sofa_find_package(image QUIET)
 
+list(APPEND SOURCE_FILES Refine2DMesh_test.cpp)
 
 if(image_FOUND)
-    find_package(Sofa.Component.StateContainer REQUIRED)
-    find_package(SceneCreator REQUIRED)
+    find_package(Sofa.Component.StateContainer REQUIRED)    
 
     list(APPEND SOURCE_FILES MeshGenerationFromImage_test.cpp)
-
-    # IMPORTANT NOTICE:
-    # the following 4 lines must be put outside of the "if" section as soon as there is another source file added to the project
-    add_definitions("-DSOFACGAL_TEST_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../scenes/data/\"")
-    add_executable(${PROJECT_NAME} ${HEADER_FILES} ${SOURCE_FILES})
-    target_link_libraries(${PROJECT_NAME} CGALPlugin Sofa.Testing Sofa.Component.StateContainer SceneCreator image)
-    add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
-
-else()
-    message(STATUS "CGALPlugin: could not find image, won't build MeshGenerationFromImage_test")
 endif()
+
+add_definitions("-DSOFACGAL_TEST_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../scenes/data/\"")
+add_executable(${PROJECT_NAME} ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} CGALPlugin Sofa.Testing SceneCreator )
+
+if(image_FOUND)
+    target_link_libraries(${PROJECT_NAME} Sofa.Component.StateContainer image)
+endif()
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/CGALPlugin_test/MeshGenerationFromImage_test.cpp
+++ b/CGALPlugin_test/MeshGenerationFromImage_test.cpp
@@ -27,7 +27,6 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
 #include <sofa/component/mass/UniformMass.h>
-#include <SceneCreator/SceneCreator.h>
 #include <sofa/component/mechanicalload/ConstantForceField.h>
 #include <sofa/simulation/common/SceneLoaderXML.h>
 
@@ -42,7 +41,6 @@ namespace cgal
 {
 
 using namespace sofa;
-using namespace modeling;
 using core::objectmodel::New;
 using sofa::simulation::SceneLoaderXML;
 using sofa::core::ExecParams;

--- a/CGALPlugin_test/Refine2DMesh_test.cpp
+++ b/CGALPlugin_test/Refine2DMesh_test.cpp
@@ -61,6 +61,7 @@ struct Refine2DMesh_test : public sofa::testing::BaseSimulationTest
 
     void checkCreation()
     {
+        test compilation error
         EXPECT_MSG_NOEMIT(Error);
 
         // Check creation

--- a/CGALPlugin_test/Refine2DMesh_test.cpp
+++ b/CGALPlugin_test/Refine2DMesh_test.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/testing/BaseSimulationTest.h>
+#include <CGALPlugin/Refine2DMesh.h>
+
+#include <sofa/simulation/common/SceneLoaderXML.h>
+
+namespace cgal
+{
+using sofa::simulation::Node;
+using sofa::simulation::SceneLoaderXML;
+
+struct Refine2DMesh_test : public sofa::testing::BaseSimulationTest
+{    
+
+    Node::SPtr createSimpleScene()
+    {
+        std::string vtkLoader = "<MeshVTKLoader name='meshLoader' filename='" + std::string(SOFACGAL_TEST_RESOURCES_DIR) + "mesh/edges.vtk' />";
+
+        std::string sceneStart =
+            "<?xml version='1.0'?>"
+            "<Node name='root' dt='0.01' gravity='0 -1 0'>"
+            "    <RequiredPlugin name='Sofa.Component.IO.Mesh'/>"
+            "    <RequiredPlugin name='CGALPlugin'/>";
+
+        std::string sceneEnd =
+            "    <Refine2DMesh template='Vec3' name='cgalTool' inputPoints='@meshLoader.position' inputEdges='@meshLoader.edges' "
+            "        useInteriorPoints='false' seedPoints='200 50 0' regionPoints='50 50 0' shapeCriteria='0.125' "
+            "        sizeCriteria='10' viewSeedPoints='1' viewRegionPoints='1' />"
+            "</Node>";
+
+        std::string scene = sceneStart + vtkLoader + sceneEnd;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("test", scene.c_str());
+
+        sofa::simulation::getSimulation()->init(root.get());
+
+        return root;
+    }
+
+
+    void checkCreation()
+    {
+        EXPECT_MSG_NOEMIT(Error);
+
+        // Check creation
+        Node::SPtr root = createSimpleScene();
+        ASSERT_NE(root.get(), nullptr);
+    }
+
+    void checkValues()
+    {
+        Node::SPtr root = createSimpleScene();
+        ASSERT_NE(root.get(), nullptr);
+
+        // Search for Refine2DMesh
+        Refine2DMesh<sofa::defaulttype::Vec3Types>* mesh = nullptr;
+        root->getTreeObject(mesh);
+        ASSERT_NE(mesh, nullptr);
+        
+        ASSERT_EQ(mesh->d_newPoints.getValue().size(), 759);
+        ASSERT_EQ(mesh->d_newEdges.getValue().size(), 101);
+        ASSERT_EQ(mesh->d_newTriangles.getValue().size(), 1415);
+    }
+};
+
+TEST_F(Refine2DMesh_test, CheckCreation) {
+    ASSERT_NO_THROW(this->checkCreation());
+}
+
+TEST_F(Refine2DMesh_test, CheckValues) {
+    ASSERT_NO_THROW(this->checkValues());
+}
+
+}

--- a/CGALPlugin_test/Refine2DMesh_test.cpp
+++ b/CGALPlugin_test/Refine2DMesh_test.cpp
@@ -61,7 +61,6 @@ struct Refine2DMesh_test : public sofa::testing::BaseSimulationTest
 
     void checkCreation()
     {
-        test compilation error
         EXPECT_MSG_NOEMIT(Error);
 
         // Check creation

--- a/scenes/Refine2DMesh.scn
+++ b/scenes/Refine2DMesh.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <Node name="root" dt="0.01" gravity="0 -1 0">
 	<VisualStyle displayFlags="showVisual showCollisionModels showWireframe"/>
     <RequiredPlugin pluginName="CGALPlugin"/>

--- a/src/CGALPlugin/CylinderMesh.h
+++ b/src/CGALPlugin/CylinderMesh.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <CGALPlugin/config.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/topology/BaseMeshTopology.h>

--- a/src/CGALPlugin/DecimateMesh.h
+++ b/src/CGALPlugin/DecimateMesh.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <CGALPlugin/config.h>
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/type/Vec.h>

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron.h
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron.h
@@ -23,7 +23,7 @@
 
 #define CGAL_MESH_3_VERBOSE 0
 
-
+#include <CGALPlugin/config.h>
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/visual/VisualParams.h>

--- a/src/CGALPlugin/Refine2DMesh.cpp
+++ b/src/CGALPlugin/Refine2DMesh.cpp
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #define CGALPLUGIN_REFINE2DMESH_CPP
 
-#include <CGALPlugin/config.h>
 #include <CGALPlugin/Refine2DMesh.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>

--- a/src/CGALPlugin/Refine2DMesh.h
+++ b/src/CGALPlugin/Refine2DMesh.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <CGALPlugin/config.h>
 #include <sofa/type/Vec.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/DataEngine.h>
@@ -93,7 +94,7 @@ public:
 };
 
 #if !defined(CGALPLUGIN_REFINE2DMESH_CPP)
-template class SOFA_CGALPLUGIN_API Refine2DMesh<sofa::defaulttype::Vec3Types>;
+extern template class SOFA_CGALPLUGIN_API Refine2DMesh<sofa::defaulttype::Vec3Types>;
 #endif
 
 } //cgal

--- a/src/CGALPlugin/TriangularConvexHull3D.h
+++ b/src/CGALPlugin/TriangularConvexHull3D.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <CGALPlugin/config.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/topology/BaseMeshTopology.h>


### PR DESCRIPTION
- Remove build with SOFA 22.06 as master branch is not anymore compatible. 
- Add test execution on the ci