### PR TITLE
Avoid RAM explosion during CGAL compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ if(image_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC image CGAL::CGAL_ImageIO)
 endif()
 
+set_property(GLOBAL PROPERTY JOB_POOLS one_jobs=1 two_jobs=2 three_jobs=3 four_jobs=4)
+set_property(TARGET ${PROJECT_NAME} PROPERTY JOB_POOL_COMPILE four_jobs)
 
 # Install rules for the library and the headers; CMake package configurations files
 sofa_create_package_with_targets(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,7 @@ if(image_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC image CGAL::CGAL_ImageIO)
 endif()
 
-set_property(GLOBAL PROPERTY JOB_POOLS one_jobs=1 two_jobs=2 three_jobs=3 four_jobs=4)
-set_property(TARGET ${PROJECT_NAME} PROPERTY JOB_POOL_COMPILE four_jobs)
+set_property(TARGET ${PROJECT_NAME} PROPERTY JOB_POOL_COMPILE 4)
 
 # Install rules for the library and the headers; CMake package configurations files
 sofa_create_package_with_targets(


### PR DESCRIPTION
Set JOB_POOL_COMPILE to 4 so ninja will only allow 4 parallel jobs during the compilation of CGALPlugin. This avoids to fill the RAM on the ci builder (it keeps the overall used RAM under 12Go on ubuntu).  
This will enable to compile sofa with more cores on the ci and will accelerate the compilation.