### PR TITLE
Refresh ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
-        sofa_branch: [master, v22.12]
+        os: [ubuntu-22.04, macos-14, windows-2022]
+        sofa_branch: [master]
 
     steps:
       # https://github.com/actions/runner-images/issues/6817
@@ -33,7 +33,7 @@ jobs:
             
       - name: Setup SOFA and environment
         id: sofa
-        uses: sofa-framework/sofa-setup-action@v4
+        uses: sofa-framework/sofa-setup-action@v5
         with:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}


### PR DESCRIPTION
not compiling for windows (setup error) and mac (cgal version too recent)