### PR TITLE
Fix mesh_criteria_3 parameters name change in CGAL >= v3.8

### DIFF
--- a/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
@@ -251,6 +251,9 @@ void MeshGenerationFromPolyhedron<DataTypes>::doUpdate()
     Mesh_criteria criteria(
             #if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
                 edge_size=sharpEdgeSize.getValue(),
+                cell_radius_edge_ratio=cellRatio.getValue(),
+            #else
+                cell_radius_edge=cellRatio.getValue(),
             #endif
 
                 facet_angle=facetAngle.getValue(), facet_size=facetSize.getValue(), facet_distance=facetApproximation.getValue(),


### PR DESCRIPTION
Parameter `cell_radius_edge` became `cell_radius_edge_ratio` starting from CGAL v3.8.
See v3.8 doc:
https://doc.cgal.org/Manual/3.8/doc_html/cgal_manual/Mesh_3_ref/Class_Mesh_criteria_3.html
vs 3.7 doc:
https://doc.cgal.org/Manual/3.8/doc_html/cgal_manual/Mesh_3_ref/Class_Mesh_criteria_3.html

Tested locally with CGAL v6.0.1.