### PR TITLE
Fix CGAL >=4.13 compat for tests with image plugin

### DIFF
--- a/src/CGALPlugin/MeshGenerationFromImage.h
+++ b/src/CGALPlugin/MeshGenerationFromImage.h
@@ -33,7 +33,13 @@
 #include <CGAL/Mesh_triangulation_3.h>
 #include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #include <CGAL/Mesh_criteria_3.h>
+
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
+#include <CGAL/Labeled_mesh_domain_3.h>
+#else
 #include <CGAL/Labeled_image_mesh_domain_3.h>
+#endif
+
 #include <CGAL/Mesh_domain_with_polyline_features_3.h>
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/refine_mesh_3.h>
@@ -68,7 +74,11 @@ public:
 
 	// Domain
     // (we use exact intersection computation with Robust_intersection_traits_3)
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
+    typedef CGAL::Mesh_domain_with_polyline_features_3<CGAL::Labeled_mesh_domain_3<K> >    Mesh_domain;
+#else
     typedef CGAL::Mesh_domain_with_polyline_features_3<CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3,K> >    Mesh_domain;
+#endif
     typedef K::Point_3 Point3;
 
     typedef std::vector<Point3>	 Polyline;

--- a/src/CGALPlugin/MeshGenerationFromImage.inl
+++ b/src/CGALPlugin/MeshGenerationFromImage.inl
@@ -206,8 +206,11 @@ void MeshGenerationFromImage<DataTypes, _ImageTypes>::doUpdate()
         image3.read(this->d_filename.getFullPath().c_str());
     }
 
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
+    Mesh_domain domain = Mesh_domain::create_labeled_image_mesh_domain(image3);
+#else
     Mesh_domain domain(image3);
-
+#endif
     int volume_dimension = 3;
     Sizing_field size(d_cellSize.getValue());
 
@@ -228,9 +231,16 @@ void MeshGenerationFromImage<DataTypes, _ImageTypes>::doUpdate()
 
 #if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,6,0)
     msg_info(this) << "Create Mesh";
-    Mesh_criteria criteria(edge_size=d_edgeSize.getValue(),
+    Mesh_criteria criteria(
+        #if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
+            edge_size=d_edgeSize.getValue(),
+            cell_radius_edge_ratio=d_cellRatio.getValue(),
+        #else
+            cell_radius_edge=d_cellRatio.getValue(),
+        #endif
+
         facet_angle=d_facetAngle.getValue(), facet_size=d_facetSize.getValue(), facet_distance=d_facetApproximation.getValue(),
-        cell_radius_edge=d_cellRatio.getValue(), cell_size=size);
+        cell_size=size);
 
     size_t nfts = fts.size();
     Polylines polylines (nfts);


### PR DESCRIPTION
Continuation of #30. Some CGAL API update fixes were missing at it was located on tests only compiled when the plugin image is present, so it was missed locally and on the CI.