### PR TITLE
Try reducing object file creation ram requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HEADER_FILES
     ${PLUGIN_CGAL_SRC_DIR}/config.h.in
     ${PLUGIN_CGAL_SRC_DIR}/DecimateMesh.h
     ${PLUGIN_CGAL_SRC_DIR}/DecimateMesh.inl
+    ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromPolyhedron_explicit.h
     ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromPolyhedron.h
     ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromPolyhedron.inl
     ${PLUGIN_CGAL_SRC_DIR}/TriangularConvexHull3D.h
@@ -14,6 +15,7 @@ set(HEADER_FILES
     ${PLUGIN_CGAL_SRC_DIR}/CylinderMesh.inl
     ${PLUGIN_CGAL_SRC_DIR}/Refine2DMesh.h
     ${PLUGIN_CGAL_SRC_DIR}/Refine2DMesh.inl
+    ${PLUGIN_CGAL_SRC_DIR}/PoissonSurfaceReconstruction_explicit.h
     ${PLUGIN_CGAL_SRC_DIR}/PoissonSurfaceReconstruction.h
     ${PLUGIN_CGAL_SRC_DIR}/FrontSurfaceReconstruction.h
     ${PLUGIN_CGAL_SRC_DIR}/UpsamplePointCloud.h
@@ -22,10 +24,12 @@ set(HEADER_FILES
 set(SOURCE_FILES
     ${PLUGIN_CGAL_SRC_DIR}/initCGALPlugin.cpp
     ${PLUGIN_CGAL_SRC_DIR}/DecimateMesh.cpp
+    ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromPolyhedron_explicit.cpp
     ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromPolyhedron.cpp
     ${PLUGIN_CGAL_SRC_DIR}/TriangularConvexHull3D.cpp
     ${PLUGIN_CGAL_SRC_DIR}/CylinderMesh.cpp
     ${PLUGIN_CGAL_SRC_DIR}/Refine2DMesh.cpp
+    ${PLUGIN_CGAL_SRC_DIR}/PoissonSurfaceReconstruction_explicit.cpp
     ${PLUGIN_CGAL_SRC_DIR}/PoissonSurfaceReconstruction.cpp
     ${PLUGIN_CGAL_SRC_DIR}/FrontSurfaceReconstruction.cpp
     ${PLUGIN_CGAL_SRC_DIR}/UpsamplePointCloud.cpp
@@ -44,7 +48,9 @@ message(STATUS "CGAL VERSION = ${CGAL_VERSION}")
 sofa_find_package(image QUIET)
 if(image_FOUND)
     find_package(CGAL REQUIRED COMPONENTS ImageIO)
-    
+
+    list(APPEND SOURCE_FILES ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromImage_explicit.h)
+    list(APPEND SOURCE_FILES ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromImage_explicit.cpp)
     list(APPEND HEADER_FILES ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromImage.h)
     list(APPEND HEADER_FILES ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromImage.inl)
     list(APPEND SOURCE_FILES ${PLUGIN_CGAL_SRC_DIR}/MeshGenerationFromImage.cpp)

--- a/src/CGALPlugin/MeshGenerationFromImage.h
+++ b/src/CGALPlugin/MeshGenerationFromImage.h
@@ -28,26 +28,8 @@
 
 #include <image/CImgData.h>
 
-#include <CGAL/version.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Mesh_triangulation_3.h>
-#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
-#include <CGAL/Mesh_criteria_3.h>
+#include <CGALPlugin/MeshGenerationFromImage_explicit.h>
 
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
-#include <CGAL/Labeled_mesh_domain_3.h>
-#else
-#include <CGAL/Labeled_image_mesh_domain_3.h>
-#endif
-
-#include <CGAL/Mesh_domain_with_polyline_features_3.h>
-#include <CGAL/make_mesh_3.h>
-#include <CGAL/refine_mesh_3.h>
-#include <CGAL/Image_3.h>
-#include <CGAL/Weighted_point_3.h>
-
-//CGAL
-typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
 namespace cgal
 {
@@ -72,35 +54,7 @@ public:
     typedef sofa::core::topology::BaseMeshTopology::Tetra Tetra;
     typedef sofa::core::topology::BaseMeshTopology::SeqTetrahedra SeqTetrahedra;
 
-	// Domain
-    // (we use exact intersection computation with Robust_intersection_traits_3)
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
-    typedef CGAL::Mesh_domain_with_polyline_features_3<CGAL::Labeled_mesh_domain_3<K> >    Mesh_domain;
-#else
-    typedef CGAL::Mesh_domain_with_polyline_features_3<CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3,K> >    Mesh_domain;
-#endif
-    typedef K::Point_3 Point3;
 
-    typedef std::vector<Point3>	 Polyline;
-    typedef std::list<Polyline>	 Polylines;
-
-    // Triangulation
-    typedef typename CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
-    typedef typename CGAL::Mesh_complex_3_in_triangulation_3<Tr,Mesh_domain::Corner_index,Mesh_domain::Curve_segment_index> C3t3;
-
-    // Mesh Criteria
-    typedef typename CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
-    typedef typename Mesh_criteria::Facet_criteria Facet_criteria;
-    typedef typename Mesh_criteria::Cell_criteria Cell_criteria;
-
-    typedef typename C3t3::Facet_iterator Facet_iterator;
-    typedef typename C3t3::Cell_iterator Cell_iterator;
-
-    typedef typename Tr::Finite_vertices_iterator Finite_vertices_iterator;
-    typedef typename Tr::Vertex_handle Vertex_handle;
-    typedef typename Tr::Point Point_3;
-	typedef CGAL::Mesh_constant_domain_field_3<Mesh_domain::R,
-                                           Mesh_domain::Index> Sizing_field;
 
     // image data
     typedef _ImageTypes ImageTypes;
@@ -115,6 +69,9 @@ public:
     typedef sofa::helper::WriteAccessor<sofa::core::objectmodel::Data< TransformType > > waTransform;
     typedef sofa::helper::ReadAccessor<sofa::core::objectmodel::Data< TransformType > > raTransform;
 
+
+    typedef std::vector<Point3> Polyline;
+    typedef std::list<Polyline> Polylines;
 
 public:
     MeshGenerationFromImage();

--- a/src/CGALPlugin/MeshGenerationFromImage.inl
+++ b/src/CGALPlugin/MeshGenerationFromImage.inl
@@ -23,14 +23,12 @@
 
 #include <CGALPlugin/MeshGenerationFromImage.h>
 #include <sofa/type/Quat.h>
+#include <CGAL/Image_3.h>
 
 using namespace sofa;
 
 #define SQR(X)   ((X)*(X))
 
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,5,0)
-using namespace CGAL::parameters;
-#endif
 
 namespace cgal
 {
@@ -207,7 +205,7 @@ void MeshGenerationFromImage<DataTypes, _ImageTypes>::doUpdate()
     }
 
 #if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
-    Mesh_domain domain = Mesh_domain::create_labeled_image_mesh_domain(image3);
+    Mesh_domain   domain = Mesh_domain::create_labeled_image_mesh_domain(image3);
 #else
     Mesh_domain domain(image3);
 #endif

--- a/src/CGALPlugin/MeshGenerationFromImage_explicit.cpp
+++ b/src/CGALPlugin/MeshGenerationFromImage_explicit.cpp
@@ -1,0 +1,24 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT_CPP
+
+#include <CGALPlugin/MeshGenerationFromImage_explicit.h>

--- a/src/CGALPlugin/MeshGenerationFromImage_explicit.h
+++ b/src/CGALPlugin/MeshGenerationFromImage_explicit.h
@@ -1,0 +1,116 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+
+#ifdef CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT_CPP
+#define CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT
+#else
+#define CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT extern
+#endif
+
+#include <image/CImgData.h>
+
+#include <CGAL/version.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Mesh_triangulation_3.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_criteria_3.h>
+
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,13,0)
+#include <CGAL/Labeled_mesh_domain_3.h>
+#else
+#include <CGAL/Labeled_image_mesh_domain_3.h>
+#endif
+
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_domain_with_polyline_features_3.h>
+#include <CGAL/make_mesh_3.h>
+#include <CGAL/refine_mesh_3.h>
+#include <CGAL/Image_3.h>
+#include <CGAL/Weighted_point_3.h>
+
+
+namespace cgal
+{
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef typename cgal::K::Point_3 Point3;
+typedef std::vector<Point3> Polyline;
+typedef std::list<Polyline> Polylines;
+
+}
+
+namespace CGAL {
+// Domain
+// (we use exact intersection computation with Robust_intersection_traits_3)
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4, 13, 0)
+CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT template class Mesh_domain_with_polyline_features_3<Labeled_mesh_domain_3<typename cgal::K>>;
+#else
+CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT template class Mesh_domain_with_polyline_features_3<Labeled_image_mesh_domain_3<Image_3, K>>;
+#endif
+
+}
+
+namespace cgal
+{
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4, 13, 0)
+typedef CGAL::Mesh_domain_with_polyline_features_3<CGAL::Labeled_mesh_domain_3<typename cgal::K>> Mesh_domain;
+#else
+typedef CGAL::Mesh_domain_with_polyline_features_3<CGAL::Labeled_image_mesh_domain_3<CGAL::Image_3, K>> Mesh_domain;
+#endif
+}
+
+namespace CGAL
+{
+// Triangulation
+CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT template class Mesh_triangulation_3<typename cgal::Mesh_domain>;
+//This is not compiling because it seems like there is a real issue in the API where a zero-argument constructor is missing. Yet, without explicit instantiation, the code is actually working....
+//CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT template class CGAL::Mesh_complex_3_in_triangulation_3<CGAL::Mesh_triangulation_3<typename cgal::Mesh_domain>::type, typename cgal::Mesh_domain::Corner_index, typename cgal::Mesh_domain::Curve_segment_index>;
+CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT template class Mesh_criteria_3<Mesh_triangulation_3<typename cgal::Mesh_domain>::type>;
+CGALPLUGIN_MESHGENERATIONFROMIMAGE_EXPLICIT template class Mesh_constant_domain_field_3<cgal::Mesh_domain::R, cgal::Mesh_domain::Index>;
+}
+
+namespace cgal
+{
+// Triangulation
+typedef typename CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+typedef typename CGAL::Mesh_complex_3_in_triangulation_3<CGAL::Mesh_triangulation_3<Mesh_domain>::type, Mesh_domain::Corner_index, Mesh_domain::Curve_segment_index> C3t3;
+
+// Mesh Criteria
+typedef typename CGAL::Mesh_criteria_3<CGAL::Mesh_triangulation_3<Mesh_domain>::type> Mesh_criteria;
+typedef typename Mesh_criteria::Facet_criteria Facet_criteria;
+typedef typename Mesh_criteria::Cell_criteria Cell_criteria;
+
+typedef typename C3t3::Facet_iterator Facet_iterator;
+typedef typename C3t3::Cell_iterator Cell_iterator;
+
+typedef typename Tr::Finite_vertices_iterator Finite_vertices_iterator;
+typedef typename Tr::Vertex_handle Vertex_handle;
+typedef typename Tr::Point Point_3;
+typedef CGAL::Mesh_constant_domain_field_3<Mesh_domain::R, Mesh_domain::Index> Sizing_field;
+
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,5,0)
+using namespace CGAL::parameters;
+#endif
+
+
+}

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron.h
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron.h
@@ -29,10 +29,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-#include <CGAL/version.h>
-
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polyhedron_incremental_builder_3.h>
+#include <CGALPlugin/MeshGenerationFromPolyhedron_explicit.h>
 
 
 namespace cgal

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron.inl
@@ -23,36 +23,10 @@
 
 #include <CGALPlugin/MeshGenerationFromPolyhedron.h>
 
-#if CGAL_VERSION_NR <= CGAL_VERSION_NUMBER(4,9,1)
-#include <CGAL/AABB_intersections.h>
-#endif
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
-
-#include <CGAL/Mesh_triangulation_3.h>
-#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
-#include <CGAL/Mesh_criteria_3.h>
-
-#include <CGAL/Polyhedral_mesh_domain_3.h>
-#include <CGAL/make_mesh_3.h>
-#include <CGAL/refine_mesh_3.h>
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
-#include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
-#endif
-
-// IO
-#include <CGAL/IO/Polyhedron_iostream.h>
-
-
-//CGAL
-//struct K: public CGAL::Exact_predicates_inexact_constructions_kernel {};
-typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
 using namespace sofa;
 
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,5,0)
-using namespace CGAL::parameters;
-#endif
+
 
 namespace cgal
 {
@@ -159,42 +133,6 @@ void printStats(C3t3& c3t3, Obj* obj, const char* step = "")
 template <class DataTypes>
 void MeshGenerationFromPolyhedron<DataTypes>::doUpdate()
 {
-    // Domain
-    // (we use exact intersection computation with Robust_intersection_traits_3)
-
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
-    typedef typename CGAL::Mesh_3::Robust_intersection_traits_3<K> Geom_traits;
-    //typedef K Geom_traits;
-    typedef typename CGAL::Mesh_polyhedron_3<Geom_traits>::type Polyhedron;
-    typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
-    typedef typename CGAL::Polyhedral_mesh_domain_with_features_3<Geom_traits, Polyhedron> Mesh_domain;
-#else
-    typedef typename CGAL::Mesh_3::Robust_intersection_traits_3<K> Geom_traits;
-    typedef typename CGAL::Polyhedron_3<Geom_traits> Polyhedron;
-    typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
-    typedef typename CGAL::Polyhedral_mesh_domain_3<Polyhedron, Geom_traits> Mesh_domain;
-#endif
-
-
-    // Triangulation
-    typedef typename CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
-    typedef typename CGAL::Mesh_complex_3_in_triangulation_3<Tr, Mesh_domain::Corner_index, Mesh_domain::Curve_segment_index> C3t3;
-#else
-    typedef typename CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
-#endif
-
-    // Mesh Criteria
-    typedef typename CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
-    // typedef typename Mesh_criteria::Facet_criteria Facet_criteria;
-    // typedef typename Mesh_criteria::Cell_criteria Cell_criteria;
-
-    // typedef typename C3t3::Facet_iterator Facet_iterator;
-    typedef typename C3t3::Cell_iterator Cell_iterator;
-
-    typedef typename Tr::Finite_vertices_iterator Finite_vertices_iterator;
-    typedef typename Tr::Vertex_handle Vertex_handle;
-    typedef typename Tr::Point Point_3;
 
     const VecCoord& oldPoints = f_X0.getValue();
     const SeqTriangles& triangles = f_triangles.getValue();

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron_explicit.cpp
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron_explicit.cpp
@@ -1,0 +1,24 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT_CPP
+
+#include <CGALPlugin/MeshGenerationFromPolyhedron_explicit.h>

--- a/src/CGALPlugin/MeshGenerationFromPolyhedron_explicit.h
+++ b/src/CGALPlugin/MeshGenerationFromPolyhedron_explicit.h
@@ -1,0 +1,136 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+
+#ifdef CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT_CPP
+#define CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT
+#else
+#define CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT extern
+#endif
+
+#define CGAL_MESH_3_VERBOSE 0
+
+#include <CGAL/version.h>
+
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polyhedron_incremental_builder_3.h>
+
+
+#if CGAL_VERSION_NR <= CGAL_VERSION_NUMBER(4,9,1)
+#include <CGAL/AABB_intersections.h>
+#endif
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
+
+#include <CGAL/Mesh_triangulation_3.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_criteria_3.h>
+
+#include <CGAL/Polyhedral_mesh_domain_3.h>
+#include <CGAL/make_mesh_3.h>
+#include <CGAL/refine_mesh_3.h>
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
+#include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
+#endif
+
+// IO
+#include <CGAL/IO/Polyhedron_iostream.h>
+
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,5,0)
+using namespace CGAL::parameters;
+#endif
+
+namespace cgal
+{
+  typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+}
+
+namespace CGAL
+{
+
+#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
+  CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class Mesh_3::Robust_intersection_traits_3<cgal::K>;
+  CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class Mesh_polyhedron_3<Mesh_3::Robust_intersection_traits_3<cgal::K>> ;
+  CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class Polyhedral_mesh_domain_with_features_3<Mesh_3::Robust_intersection_traits_3<cgal::K>, typename Mesh_polyhedron_3<Mesh_3::Robust_intersection_traits_3<cgal::K>>::type>;
+#else
+  CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT Mesh_3::Robust_intersection_traits_3<cgal::K>;
+  CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT Polyhedron_3<Mesh_3::Robust_intersection_traits_3<cgal::K>>;
+  CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT Polyhedral_mesh_domain_3<Polyhedron_3<Mesh_3::Robust_intersection_traits_3<cgal::K>>, Mesh_3::Robust_intersection_traits_3<cgal::K>>;
+#endif
+}
+
+namespace cgal
+{
+  #if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
+  typedef typename CGAL::Mesh_3::Robust_intersection_traits_3<K> Geom_traits;
+  typedef typename CGAL::Mesh_polyhedron_3<Geom_traits>::type Polyhedron;
+  typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
+  typedef typename CGAL::Polyhedral_mesh_domain_with_features_3<Geom_traits, Polyhedron> Mesh_domain;
+  #else
+  typedef typename CGAL::Mesh_3::Robust_intersection_traits_3<K> Geom_traits;
+  typedef typename CGAL::Polyhedron_3<Geom_traits> Polyhedron;
+  typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
+  typedef typename CGAL::Polyhedral_mesh_domain_3<Polyhedron, Geom_traits> Mesh_domain;
+  #endif
+
+}
+
+namespace CGAL
+{
+
+CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class Polyhedron_incremental_builder_3<cgal::Polyhedron::HalfedgeDS>;
+
+
+  // Triangulation
+CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class CGAL::Mesh_triangulation_3<cgal::Mesh_domain>;
+//#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
+//CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class CGAL::Mesh_complex_3_in_triangulation_3<CGAL::Mesh_triangulation_3<cgal::Mesh_domain>::type, cgal::Mesh_domain::Corner_index, cgal::Mesh_domain::Curve_segment_index>;
+//#else
+//CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT CGAL::Mesh_complex_3_in_triangulation_3<CGAL::Mesh_triangulation_3<cgal::Mesh_domain>::type> C3t3;
+//#endif
+
+  // Mesh Criteria
+CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_EXPLICIT template class CGAL::Mesh_criteria_3<CGAL::Mesh_triangulation_3<cgal::Mesh_domain>::type>;
+
+}
+
+namespace cgal
+{
+  // Triangulation
+  typedef typename CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
+  #if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(3,8,0)
+  typedef typename CGAL::Mesh_complex_3_in_triangulation_3<Tr, Mesh_domain::Corner_index, Mesh_domain::Curve_segment_index> C3t3;
+  #else
+  typedef typename CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
+  #endif
+
+  // Mesh Criteria
+  typedef typename CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
+
+  typedef typename C3t3::Cell_iterator Cell_iterator;
+
+  typedef typename Tr::Finite_vertices_iterator Finite_vertices_iterator;
+  typedef typename Tr::Vertex_handle Vertex_handle;
+  typedef typename Tr::Point Point_3;
+
+}

--- a/src/CGALPlugin/PoissonSurfaceReconstruction.cpp
+++ b/src/CGALPlugin/PoissonSurfaceReconstruction.cpp
@@ -20,10 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <CGALPlugin/PoissonSurfaceReconstruction.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/poisson_surface_reconstruction.h>
-#include <CGAL/property_map.h>
+
 #include <CGALPlugin/config.h>
 #include <sofa/core/ObjectFactory.h>
 
@@ -37,14 +34,6 @@ namespace cgal
 {
 
 using sofa::core::objectmodel::ComponentState ;
-
-typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef Kernel::Point_3 Point_3;
-typedef Kernel::Vector_3 Vector_3;
-typedef std::pair<Point_3, Vector_3> Pwn;
-typedef CGAL::Polyhedron_3<Kernel> Polyhedron_3;
-typedef Polyhedron_3::Vertex_handle Vertex_handle;
-typedef Polyhedron_3::Halfedge_around_facet_circulator HF_circulator;
 
 PoissonSurfaceReconstruction::PoissonSurfaceReconstruction()
     : d_positionsIn(initData (&d_positionsIn, "position", "Input point cloud positions"))

--- a/src/CGALPlugin/PoissonSurfaceReconstruction.h
+++ b/src/CGALPlugin/PoissonSurfaceReconstruction.h
@@ -24,6 +24,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <CGALPlugin/PoissonSurfaceReconstruction_explicit.h>
 
 namespace cgal
 {

--- a/src/CGALPlugin/PoissonSurfaceReconstruction_explicit.cpp
+++ b/src/CGALPlugin/PoissonSurfaceReconstruction_explicit.cpp
@@ -1,0 +1,24 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define CGALPLUGIN_POISSONSURFACERECONSTRUCTION_EXPLICIT_CPP
+
+#include <CGALPlugin/PoissonSurfaceReconstruction_explicit.h>

--- a/src/CGALPlugin/PoissonSurfaceReconstruction_explicit.h
+++ b/src/CGALPlugin/PoissonSurfaceReconstruction_explicit.h
@@ -1,0 +1,67 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+
+#ifdef CGALPLUGIN_POISSONSURFACERECONSTRUCTION_EXPLICIT_CPP
+#define CGALPLUGIN_POISSONSURFACERECONSTRUCTION_EXPLICIT
+#else
+#define CGALPLUGIN_POISSONSURFACERECONSTRUCTION_EXPLICIT extern
+#endif
+
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/poisson_surface_reconstruction.h>
+#include <CGAL/property_map.h>
+
+namespace cgal
+{
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+typedef Kernel::Point_3 Point_3;
+typedef Kernel::Vector_3 Vector_3;
+typedef std::pair<Point_3, Vector_3> Pwn;
+typedef CGAL::Polyhedron_3<Kernel> Polyhedron_3;
+typedef Polyhedron_3::Vertex_handle Vertex_handle;
+typedef Polyhedron_3::Halfedge_around_facet_circulator HF_circulator;
+
+}
+
+namespace CGAL
+{
+   CGALPLUGIN_POISSONSURFACERECONSTRUCTION_EXPLICIT template bool poisson_surface_reconstruction_delaunay<std::vector<cgal::Pwn>::iterator,
+                                                        First_of_pair_property_map<cgal::Pwn>,
+                                                        Second_of_pair_property_map<cgal::Pwn>,
+                                                        cgal::Polyhedron_3,
+                                                        Manifold_with_boundary_tag>
+    (std::vector<cgal::Pwn>::iterator,
+     std::vector<cgal::Pwn>::iterator,
+     First_of_pair_property_map<cgal::Pwn> ,
+     Second_of_pair_property_map<cgal::Pwn>,
+     cgal::Polyhedron_3& ,
+     double ,
+     double  ,
+     double ,
+     double ,
+     Manifold_with_boundary_tag);
+}


### PR DESCRIPTION
This is a last try for continuing having CGALPlugin built on the main CI. Here I am trying to instanciate explictly some parts of CGAL components used in the two biggest components. 

The main issue here is that doing the same for some methods is close to impossible: CGAL is using a lot of template meta programming with template pack, leading to a very hard, nearly impossible to guess signature.  