### PR TITLE
Add cron for nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   workflow_dispatch:
   push:
+  schedule:
+    - cron:  '0 5 * * *' # nightly job at 5 a.m. UTC to make sure sofa's nightly is available
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Add nightly as this plugin will no longer be nuilt bny the main CI

This PR goes along with the two following PRs:
[SOFA #5869](https://github.com/sofa-framework/sofa/pull/5869)
[SofaPython3 #567](https://github.com/sofa-framework/SofaPython3/pull/567)